### PR TITLE
Fix case mismatch in filename (causes compilation failure in linux).

### DIFF
--- a/verilog/imp/cam_proj.qsf
+++ b/verilog/imp/cam_proj.qsf
@@ -184,7 +184,7 @@ set_global_assignment -name VERILOG_FILE ../code/neuroset/TOP.v
 set_global_assignment -name VERILOG_FILE ../code/neuroset/result.v
 set_global_assignment -name VERILOG_FILE ../code/neuroset/RAMtoMEM.v
 set_global_assignment -name VERILOG_FILE ../code/neuroset/RAM.v
-set_global_assignment -name VERILOG_FILE ../code/neuroset/MaxPooling.v
+set_global_assignment -name VERILOG_FILE ../code/neuroset/maxpooling.v
 set_global_assignment -name VERILOG_FILE ../code/neuroset/dense.v
 set_global_assignment -name VERILOG_FILE ../code/neuroset/database.v
 set_global_assignment -name VERILOG_FILE ../code/neuroset/conv_TOP.v


### PR DESCRIPTION
Simple case mismatch in filename, fixed. This would not have caused a problem in windows, because its filename handling is case insensitive. The problem was noted in #9, but I saw no resolution there. 